### PR TITLE
expose factories so they can be used by plugins, for example

### DIFF
--- a/lib/binda/factories.rb
+++ b/lib/binda/factories.rb
@@ -1,0 +1,3 @@
+GEM_ROOT = File.dirname(File.dirname(File.dirname(__FILE__)))
+Dir[File.join(GEM_ROOT, 'spec', 'factories', '*.rb')].each { |file| require(file) }
+


### PR DESCRIPTION
I am developing a plugin for Binda and I need to access Binda factories to avoid duplication and simplify my work.
This pull requests adds a factories.rb file inside lib folder that requires all factories and can be included in external plugins.