### PR TITLE
complete URLs for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ This lets you create another temporary super admin user.
 
 ## Specific needs
 In order to use Carrierwave to process images you need to run MiniMagik. Please refer to [Carrierwave documentation](https://github.com/carrierwaveuploader/carrierwave#using-minimagick) to find more information.
+If you need absolute URLs for your images remember to set up your asset host in config/environments/production.rb
+
+```ruby
+Rails.application.configure do
+  ...
+  config.action_controller.asset_host = 'http://your.host.com'
+  ...
+end
+```
 
 If you are not going to use Rails default ORM please check [Carrierwave documentation](https://github.com/carrierwaveuploader/carrierwave#datamapper-mongoid-sequel) and [Devise documentation](https://github.com/plataformatec/devise#other-orms).
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ This lets you create another temporary super admin user.
 
 ## Specific needs
 In order to use Carrierwave to process images you need to run MiniMagik. Please refer to [Carrierwave documentation](https://github.com/carrierwaveuploader/carrierwave#using-minimagick) to find more information.
+
 If you need absolute URLs for your images remember to set up your asset host in config/environments/production.rb
 
 ```ruby

--- a/lib/generators/binda/install/templates/config/initializers/carrierwave.rb
+++ b/lib/generators/binda/install/templates/config/initializers/carrierwave.rb
@@ -1,5 +1,6 @@
 CarrierWave.configure do |config|
   config.storage = :file
+  config.asset_host = ActionController::Base.asset_host
 
 
   # # If you prefer to use Google uncomment and udpate the following lines


### PR DESCRIPTION
This pull request adds default configuration for carrierwave in order to provide complete URLs for images instead of just paths. It also adds instructions to set up application's asset_host.