### PR TITLE
Popup Warning

### DIFF
--- a/app/assets/stylesheets/binda/components/popup_warning.scss
+++ b/app/assets/stylesheets/binda/components/popup_warning.scss
@@ -35,6 +35,11 @@
 }
 
 .popup-warning--loader {
+  transition: opacity 0.1s 0.1s linear;
+  &.popup-warning--loader--hidden {
+    opacity: 0;
+  }
+  opacity: 1;
   margin-bottom: 16px;
   span {
     display: inline-block;
@@ -54,5 +59,20 @@
   }
   span:nth-child(4) {
     animation-delay: 540ms;
+  }
+}
+
+.popup-warning--success {
+  transition: opacity 0.1s 0.1s linear;
+  opacity: 1;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 16px;
+  color: $color-success;
+  font-size: 30px;
+
+  &.popup-warning--success--hidden {
+    opacity: 0;
   }
 }

--- a/app/views/binda/fieldable/_form_body.html.erb
+++ b/app/views/binda/fieldable/_form_body.html.erb
@@ -1,4 +1,3 @@
-<%= render 'layouts/binda/popup_warning' %>
 <%= simple_form_for [ @instance.structure, @instance ], html: { class: 'form-body', multipart: true } do |f| %>
   <%= f.error_notification %>
   <%= render 'layouts/binda/form_errors', f: f %>

--- a/app/views/layouts/binda/_popup_warning.html.erb
+++ b/app/views/layouts/binda/_popup_warning.html.erb
@@ -1,4 +1,7 @@
 <div class="popup-warning popup-warning--hidden">
+    <div class="popup-warning--success popup-warning--success--hidden">
+      <i class="fas fa-check-circle"></i>
+    </div>
     <div class="popup-warning--loader">
       <span></span>
       <span></span>

--- a/app/views/layouts/binda/application.html.erb
+++ b/app/views/layouts/binda/application.html.erb
@@ -16,6 +16,7 @@
 
   <body class="<%= action_name %> <%= "#{controller_name}-#{action_name}" %> <%= 'devise-view' if is_devise_controller %>">
     
+    <%= render 'layouts/binda/popup_warning' %>
     <div id="main-container">
 
       <%= yield :background %>


### PR DESCRIPTION
We need to use the popup warning from everywhere, not just from forms.
I also added a success feedback that can be shown instead of loading bars to notify users that an operation has been completed succesfully.